### PR TITLE
Models for magento instance, websites etc #1737 #1738

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: UTF-8 -*-
+'''
+    magento-integration
+
+    :copyright: (c) 2013 by Openlabs Technologies & Consulting (P) LTD
+    :license: AGPLv3, see LICENSE for more details
+'''
+import magento_      # noqa

--- a/__openerp__.py
+++ b/__openerp__.py
@@ -1,0 +1,30 @@
+# -*- encoding: utf-8 -*-
+
+{
+    'name': 'Magento Integration',
+    'author': 'Openlabs Technologies & Consulting Pvt Ltd.',
+    'version': '0.1',
+    'depends': [
+        'base', 'sale'
+    ],
+    'category': 'Specific Industry Applications',
+    'summary': 'Magento Integration',
+    'description': """
+This module integrates OpenERP with magento.
+============================================
+
+This will import the following:
+
+* Product categories
+* Products
+* Customers
+* Addresses
+* Orders
+    """,
+    'data': ['magento.xml'],
+    'css': [],
+    'images': [],
+    'demo': [],
+    'installable': True,
+    'application': True,
+}

--- a/magento.xml
+++ b/magento.xml
@@ -5,6 +5,63 @@
         <menuitem id="menu_magento" name="Magento" sequence="70" groups="base.group_user"/>
         <menuitem id="menu_magento_config" name="Configuration" sequence="50" parent="menu_magento" groups="base.group_user"/>
 
+        <record id="magento_instance_tree_view" model="ir.ui.view">
+            <field name="name">magento.instance.tree</field>
+            <field name="model">magento.instance</field>
+            <field eval="7" name="priority"/>
+            <field name="arch" type="xml">
+                <tree string="Magento Instances">
+                    <field name="name"/>
+                    <field name="url"/>
+                    <field name="active"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="magento_instance_form_view" model="ir.ui.view">
+            <field name="name">magento.instance.form</field>
+            <field name="model">magento.instance</field>
+            <field eval="7" name="priority"/>
+            <field name="arch" type="xml">
+                <form string="Magento Instance" version="7.0">
+                    <sheet>
+                        <div class="oe_title">
+                            <div class="oe_edit_only">
+                                <label for="name" string="Name"/>
+                            </div>
+                            <h1>
+                                <field name="name"/>
+                            </h1>
+                        </div>
+                        <div class="oe_clear"/>
+                        <div class="oe_horizontal_separator oe_clear ">
+                            API Settings
+                        </div>
+                        <label for="url"/>
+                        <h3><field name="url" colspan="4"/></h3>
+                        <group>
+                            <group>
+                                <label for="api_user"/>
+                                <h3><field name="api_user"/></h3>
+                            </group>
+                            <group>
+                                <label for="api_key"/>
+                                <h3><field name="api_key"/></h3>
+                            </group>
+                        </group>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record id="magento_instances" model="ir.actions.act_window">
+            <field name="name">Magento Instances</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">magento.instance</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+        <menuitem action="magento_instances" id="menu_instances" parent="menu_magento_config" sequence="5" groups="base.group_user"/>
         <menuitem id="menu_websites" parent="menu_magento_config" sequence="10" groups="base.group_user"/>
         <menuitem id="menu_stores" parent="menu_magento_config" sequence="15" groups="base.group_user"/>
         <menuitem id="menu_store_views" parent="menu_magento_config" sequence="20" groups="base.group_user"/>

--- a/magento.xml
+++ b/magento.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <menuitem id="menu_magento" name="Magento" sequence="70" groups="base.group_user"/>
+        <menuitem id="menu_magento_config" name="Configuration" sequence="50" parent="menu_magento" groups="base.group_user"/>
+
+        <menuitem id="menu_websites" parent="menu_magento_config" sequence="10" groups="base.group_user"/>
+        <menuitem id="menu_stores" parent="menu_magento_config" sequence="15" groups="base.group_user"/>
+        <menuitem id="menu_store_views" parent="menu_magento_config" sequence="20" groups="base.group_user"/>
+
+    </data>
+</openerp>

--- a/magento_.py
+++ b/magento_.py
@@ -10,6 +10,110 @@ from openerp.osv import fields, osv
 
 class Instance(osv.Model):
     """Magento Instance
+
+    Refers to a magento installation identifiable via url, api_user and api_key
     """
     _name = 'magento.instance'
     _description = __doc__
+
+    _columns = dict(
+        name=fields.char('Name', required=True, size=50),
+        url=fields.char('Magento Site URL', required=True, size=255),
+        api_user=fields.char('API User', required=True, size=50),
+        api_key=fields.char('API Password / Key', required=True, size=100),
+        active=fields.boolean('Active'),
+        websites=fields.one2many(
+            'magento.instance.website', 'instance', 'Websites'
+        )
+    )
+
+    _defaults = dict(
+        active=lambda *a: 1,
+    )
+
+    _sql_constraints = [
+        ('url_unique', 'unique(url)', 'URL of an instance must be unique'),
+    ]
+
+
+class InstanceWebsite(osv.Model):
+    """Magento Instance Website
+
+    A magento instance can have multiple websites.
+    They act as  ‘parents’ of stores. A website consists of one or more stores.
+    """
+    _name = 'magento.instance.website'
+    _description = "Magento Instance Website"
+
+    _columns = dict(
+        name=fields.char('Name', required=True, size=50),
+        code=fields.char('Code', required=True, size=50),
+        instance=fields.many2one(
+            'magento.instance', 'Instance', required=True,
+        ),
+        stores=fields.one2many(
+            'magento.website.stores', 'website', 'Stores'
+        )
+    )
+
+    _sql_constraints = [(
+        'code_instance_unique', 'unique(code, instance)',
+        'Code of a website must be unique in an instance'
+    )]
+
+
+class WebsiteStore(osv.Model):
+    """Magento Website Store or Store view groups
+
+    Stores are ‘children’ of websites. The visibility of products and
+    categories is managed on magento at store level by specifying the
+    root category on a store.
+    """
+    _name = 'magento.website.store'
+    _description = "Magento Website Store"
+
+    _columns = dict(
+        name=fields.char('Name', required=True, size=50),
+        website=fields.many2one(
+            'magento.instance.website', 'Website', required=True,
+        ),
+        instance=fields.related(
+            'website', 'instance', type='many2one',
+            relation='magento.instance', string='Instance'
+        ),
+        store_views=fields.one2many(
+            'magento.store.store_view', 'store', 'Store Views'
+        ),
+    )
+
+
+class WebsiteStoreView(osv.Model):
+    """Magento Website Store View
+
+    A store needs one or more store views to be browse-able in the front-end.
+    It allows for multiple presentations of a store. Most implementations
+    use store views for different languages.
+    """
+    _name = 'magento.website.store_view'
+    _description = "Magento Website Store View"
+
+    _columns = dict(
+        name=fields.char('Name', required=True, size=50),
+        code=fields.char('Code', required=True, size=50),
+        store=fields.many2one(
+            'magento.website.store', 'Store', required=True,
+        ),
+        instance=fields.related(
+            'website', 'instance', type='many2one',
+            relation='magento.instance', string='Instance'
+        ),
+        website=fields.related(
+            'store', 'website', type='many2one',
+            relation='magento.instance.website', string='Website'
+        )
+    )
+
+    _sql_constraints = [(
+        'code_store_unique', 'unique(code, store)',
+        'Code of a storeview must be unique in a store'
+    )]

--- a/magento_.py
+++ b/magento_.py
@@ -1,0 +1,15 @@
+# -*- coding: UTF-8 -*-
+'''
+    magento
+
+    :copyright: (c) 2013 by Openlabs Technologies & Consulting (P) LTD
+    :license: AGPLv3, see LICENSE for more details
+'''
+from openerp.osv import fields, osv
+
+
+class Instance(osv.Model):
+    """Magento Instance
+    """
+    _name = 'magento.instance'
+    _description = __doc__

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[flake8]
+exclude=.svn,CVS,.bzr,.hg,.git,__pycache__,build,dist,upload.py
+max-complexity=10
+max-line-length=80


### PR DESCRIPTION
Initial boilerplate module with flake8 setup and basic menus for view

Review: 183001

This patch includes the models for instance, website, store and storeview
Also includes a small view for instance

Review: 186001
