### PR TITLE
Button to import order states #1891

### DIFF
--- a/magento.xml
+++ b/magento.xml
@@ -32,6 +32,10 @@
                                 type='action' class="oe_highlight" string='Test Connection'/>
                         <button name="%(action_magento_import_websites)d" 
                                 type='action' class="oe_highlight" string='Import Websites'/>
+
+                        <button name="import_order_states"
+                            string="Import order states" type="object"
+                            groups="base.group_user"/>
                     </header>
                     <sheet>
                         <div class="oe_title">


### PR DESCRIPTION
This patch has added button on magento instance to import order states
and an usererror is raised if order states are not found while importing
orders.

Task ID: project-1735/task-1891
Review ID: 227001
