### PR TITLE
Added view for magento carriers #1936

### DIFF
--- a/magento.xml
+++ b/magento.xml
@@ -118,7 +118,28 @@
                             </page>
                             <page string="Carriers" groups="base.group_user">
                                 <h3>
-                                    <field name="carriers"/>
+                                    <field name="carriers">
+                                        <form string="Carriers" version="7.0">
+                                            <group>
+                                                <group>
+                                                    <field name="code"/>
+                                                </group>
+                                                <group>
+                                                    <field name="title"/>
+                                                </group>
+                                                <group>
+                                                    <field name="carrier"/>
+                                                </group>
+                                                <group>
+                                                    <field name="instance"/>
+                                                </group>
+                                            </group>
+                                        </form>
+                                        <tree string="Carriers">
+                                            <field name="code"/>
+                                            <field name="title"/>
+                                        </tree>
+                                    </field>
                                 </h3>
                             </page>
                         </notebook>


### PR DESCRIPTION
There was no view defined for magento carriers so they were not visible
on magento instance one2many field. This patch has added view for
magento carriers.

Task ID: project-1735/task-1936
Review ID: 238001
