### PR TITLE
Handle tier pricing and export on products #1923 fixes #60

### DIFF
--- a/__openerp__.py
+++ b/__openerp__.py
@@ -32,6 +32,7 @@ This will import the following:
         'wizard/export_orders.xml',
         'wizard/import_carriers.xml',
         'wizard/export_inventory.xml',
+        'wizard/export_tier_prices.xml',
         'magento.xml',
         'sale.xml',
         'product.xml',

--- a/magento.xml
+++ b/magento.xml
@@ -199,7 +199,24 @@
                             </page>
                             <page string="Magento Products" groups="base.group_user">
                                 <h3>
-                                    <field name="magento_products"/>
+                                    <field name="magento_products">
+                                        <form string="Products" version="7.0">
+                                            <group>
+                                                <group>
+                                                    <label for="product"/>
+                                                    <h3><field name="product"/></h3>
+                                                </group>
+                                                <group>
+                                                    <label for="magento_id"/>
+                                                    <h3><field name="magento_id"/></h3>
+                                                </group>
+                                            </group>
+                                        </form>
+                                        <tree string="Products">
+                                            <field name="product"/>
+                                            <field name="magento_id"/>
+                                        </tree>
+                                    </field>
                                 </h3>
                             </page>
                         </notebook>
@@ -237,6 +254,10 @@
             <field eval="7" name="priority"/>
             <field name="arch" type="xml">
                 <form string="Website Store" version="7.0" col="6">
+                    <header>
+                        <button name="%(action_magento_export_tier_prices)d"
+                                type='action' class="oe_highlight" string='Export Tier Prices'/>
+                    </header>
                     <sheet>
                         <group>
                             <group>
@@ -281,6 +302,21 @@
                                 <h3>
                                     <field name="store_views" readonly="1"/>
                                 </h3>
+                            </page>
+                            <page string="Price Tiers" groups="base.group_user">
+                                <field name="price_tiers">
+                                    <form string="Price Tier" version="7.0">
+                                        <group>
+                                            <group>
+                                                <label for="quantity"/>
+                                                <h3><field name="quantity"/></h3>
+                                            </group>
+                                        </group>
+                                    </form>
+                                    <tree string="Price Tiers" editable="bottom">
+                                        <field name="quantity"/>
+                                    </tree>
+                                </field>
                             </page>
                         </notebook>
                     </sheet>

--- a/product.xml
+++ b/product.xml
@@ -17,7 +17,42 @@
                             <label for="magento_product_type"/>
                             <h3><field name="magento_product_type"/></h3>
                         </group>
-                        <field name= "magento_ids"/>
+                        <group col="4">
+                            <separator colspan="2" string="Magento IDs"/>
+                            <separator colspan="2" string="Price Tiers"/>
+                            <newline/>
+                            <field name= "magento_ids" colspan="2" nolabel="1">
+                                <form string="Magento IDs" version="7.0">
+                                    <group>
+                                        <group>
+                                            <label for="magento_id"/>
+                                            <h3><field name="magento_id"/></h3>
+                                        </group>
+                                        <group>
+                                            <label for="website"/>
+                                            <h3><field name="website"/></h3>
+                                        </group>
+                                    </group>
+                                </form>
+                                <tree editable="bottom">
+                                    <field name="magento_id"/>
+                                    <field name="website"/>
+                                </tree>
+                            </field>
+                            <field name= "price_tiers" colspan="2" nolabel="1">
+                                <form string="Price Tiers" version="7.0">
+                                    <group>
+                                        <group>
+                                            <label for="quantity"/>
+                                            <h3><field name="quantity"/></h3>
+                                        </group>
+                                    </group>
+                                </form>
+                                <tree editable="bottom">
+                                    <field name="quantity"/>
+                                </tree>
+                            </field>
+                        </group>
                     </page>
                 </notebook>
             </field>
@@ -31,8 +66,25 @@
                 <xpath expr="//group[@name='parent']" position="after">
                     <notebook position="inside" colspan="4">
                         <page string="Magento" groups="base.group_user" >
-                          <field name= "magento_ids"/>
-                      </page>
+                            <field name= "magento_ids" colspan="2">
+                                <form string="Magento IDs" version="7.0">
+                                    <group>
+                                        <group>
+                                            <label for="magento_id"/>
+                                            <h3><field name="magento_id"/></h3>
+                                        </group>
+                                        <group>
+                                            <label for="instance"/>
+                                            <h3><field name="instance"/></h3>
+                                        </group>
+                                    </group>
+                                </form>
+                                <tree>
+                                    <field name="magento_id"/>
+                                    <field name="instance"/>
+                                </tree>
+                            </field>
+                        </page>
                     </notebook>
                 </xpath>
             </field>

--- a/wizard/__init__.py
+++ b/wizard/__init__.py
@@ -12,4 +12,5 @@ import import_catalog
 import import_orders
 import export_orders
 import export_inventory
+import export_tier_prices
 import import_carriers

--- a/wizard/export_tier_prices.py
+++ b/wizard/export_tier_prices.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+"""
+    export_tier_prices
+
+    Exports Tier Prices
+
+    :copyright: (c) 2013 by Openlabs Technologies & Consulting (P) Limited
+    :license: AGPLv3, see LICENSE for more details.
+"""
+from openerp.osv import osv
+from openerp.tools.translate import _
+
+
+class ExportTierPrices(osv.TransientModel):
+    "Export Tier Prices"
+    _name = 'magento.store.export_tier_prices'
+
+    def export_tier_prices(self, cursor, user, ids, context):
+        """
+        Export product tier prices to magento for the current store
+
+        :param cursor: Database cursor
+        :param user: ID of current user
+        :param ids: List of ids of records for this model
+        :param context: Application context
+        :return: View for products
+        """
+        store_obj = self.pool.get('magento.website.store')
+
+        store = store_obj.browse(
+            cursor, user, context['active_id'], context
+        )
+
+        context.update({
+            'magento_store': context['active_id'],
+        })
+
+        products = store_obj.export_tier_prices_to_magento(
+            cursor, user, store, context
+        )
+
+        return self.open_products(cursor, user, map(int, products), context)
+
+    def open_products(self, cursor, user, product_ids, context):
+        """
+        Open view for products for which tier prices have been exported
+
+        :param cursor: Database cursor
+        :param user: ID of current user
+        :param product_ids: List of product ids
+        :param context: Application context
+        :return: Tree view for products
+        """
+        ir_model_data = self.pool.get('ir.model.data')
+
+        tree_res = ir_model_data.get_object_reference(
+            cursor, user, 'product', 'product_product_tree_view'
+        )
+        tree_id = tree_res and tree_res[1] or False
+
+        return {
+            'name': _('Products with tier prices exported to Magento'),
+            'view_type': 'form',
+            'view_mode': 'tree,form',
+            'res_model': 'product.product',
+            'views': [(tree_id, 'tree')],
+            'context': context,
+            'type': 'ir.actions.act_window',
+            'domain': [('id', 'in', product_ids)]
+        }

--- a/wizard/export_tier_prices.xml
+++ b/wizard/export_tier_prices.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_magento_export_tier_prices" model="ir.ui.view">
+            <field name="name">magento.store.export_tier_prices.form</field>
+            <field name="model">magento.store.export_tier_prices</field>
+            <field name="arch" type="xml">
+                <form string="Export Tier Prices" version="7.0">
+                    <group>
+                        <h3 class="oe_grey">
+                            This wizard will export product tier prices to
+                            magento for this store.
+                        </h3>
+                    </group>
+                    <footer>
+                        <button string="Continue" type="object"
+                            name="export_tier_prices" />
+                        <button string="Close" special="cancel" class="oe_link"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <record id="action_magento_export_tier_prices" model="ir.actions.act_window">
+            <field name="name">Export Inventory</field>
+            <field name="res_model">magento.store.export_tier_prices</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+           <field name="view_id" ref="view_magento_export_tier_prices"/>
+           <field name="target">new</field>
+       </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
Create price tiers for user to configure on products
A default price tier configuration exists on store
Allow export of tier prices in the configured tiers from openerp to magento

Review: 242001
