### PR TITLE
Forgive when order state is unknown #2013 fixes #79

### DIFF
--- a/sale.py
+++ b/sale.py
@@ -98,7 +98,7 @@ class MagentoOrderState(osv.Model):
                     'name': name,
                     'code': code,
                     'instance': context['magento_instance'],
-                    'openerp_state': default_order_states_map[code],
+                    'openerp_state': default_order_states_map.get(code),
                 }, context=context)
             )
 

--- a/tests/test_sale.py
+++ b/tests/test_sale.py
@@ -114,6 +114,38 @@ class TestSale(TestBase):
                     state.instance.id, context['magento_instance']
                 )
 
+    def test_0006_import_sale_order_states(self):
+        """
+        Test the import and creation of sale order states for an instance when
+        order state is unknown
+        """
+        magento_order_state_obj = POOL.get('magento.order_state')
+
+        with Transaction().start(DB_NAME, USER, CONTEXT) as txn:
+            self.setup_defaults(txn)
+            context = deepcopy(CONTEXT)
+            context.update({
+                'magento_instance': self.instance_id1,
+            })
+
+            states_before_import = magento_order_state_obj.search(
+                txn.cursor, txn.user, [], context=context
+            )
+            states = magento_order_state_obj.create_all_using_magento_data(
+                txn.cursor, txn.user, {'something': 'something'},
+                context=context
+            )
+            states_after_import = magento_order_state_obj.search(
+                txn.cursor, txn.user, [], context=context
+            )
+
+            self.assertTrue(states_after_import > states_before_import)
+
+            for state in states:
+                self.assertEqual(
+                    state.instance.id, context['magento_instance']
+                )
+
     def test_0010_import_sale_order_with_products(self):
         """
         Tests import of sale order using magento data


### PR DESCRIPTION
The order status map only has a state for known values. For unknowns the
code should just leave the openerp state empty.

Review ID: 268001
