### PR TITLE
Export catalog to magento #2008 fixes #68

### DIFF
--- a/__openerp__.py
+++ b/__openerp__.py
@@ -35,6 +35,7 @@ This will import the following:
         'wizard/export_inventory.xml',
         'wizard/export_tier_prices.xml',
         'wizard/export_shipment_status.xml',
+        'wizard/export_catalog.xml',
         'product.xml',
         'magento.xml',
         'sale.xml',

--- a/magento.xml
+++ b/magento.xml
@@ -185,6 +185,8 @@
                                 type='action' class="oe_highlight" string='Update Catalog'/>
                         <button name="%(action_magento_export_inventory)d"
                                 type='action' class="oe_highlight" string='Export Inventory'/>
+                        <button name="%(action_magento_export_catalog)d"
+                                type='action' class="oe_highlight" string='Export Catalog'/>
                     </header>
                     <sheet>
                         <group>

--- a/wizard/__init__.py
+++ b/wizard/__init__.py
@@ -16,3 +16,4 @@ import export_inventory
 import export_tier_prices
 import import_carriers
 import export_shipment_status
+import export_catalog

--- a/wizard/export_catalog.py
+++ b/wizard/export_catalog.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+"""
+    export_catalog
+
+    Exports Catalog
+
+    :copyright: (c) 2013 by Openlabs Technologies & Consulting (P) Limited
+    :license: AGPLv3, see LICENSE for more details.
+"""
+import magento
+from openerp.osv import osv, fields
+from openerp.tools.translate import _
+
+
+class ExportCatalog(osv.TransientModel):
+    "Export Catalog"
+    _name = 'magento.instance.website.export_catalog'
+    _description = __doc__
+
+    def get_attribute_sets(self, cursor, user, context=None):
+        """Get the list of attribute sets from magento for the current website's
+        instance
+
+        :param cursor: Database cursor
+        :param user: ID of current user
+        :param context: Application context
+        :return: Tuple of attribute sets where each tuple consists of (ID, Name)
+        """
+        website_obj = self.pool.get('magento.instance.website')
+
+        if not context.get('active_id'):
+            return []
+
+        website = website_obj.browse(
+            cursor, user, context['active_id'], context
+        )
+        instance = website.instance
+
+        with magento.ProductAttributeSet(
+            instance.url, instance.api_user, instance.api_key
+        ) as attribute_set_api:
+            attribute_sets = attribute_set_api.list()
+
+        return [(
+            attribute_set['set_id'], attribute_set['name']
+        ) for attribute_set in attribute_sets]
+
+    _columns = dict(
+        category=fields.many2one(
+            'product.category', 'Magento Category', required=True,
+            domain=[('magento_ids', '!=', None)],
+        ),
+        products=fields.many2many(
+            'product.product', 'website_product_rel', 'website', 'product',
+            'Products', required=True, domain=[('magento_ids', '=', None)],
+        ),
+        attribute_set=fields.selection(
+            get_attribute_sets, 'Attribute Set', required=True,
+        )
+    )
+
+    def export_catalog(self, cursor, user, ids, context):
+        """
+        Export the products selected to the selected category for this website
+
+        :param cursor: Database cursor
+        :param user: ID of current user
+        :param ids: List of ids of records for this model
+        :param context: Application context
+        """
+        website_obj = self.pool.get('magento.instance.website')
+        product_obj = self.pool.get('product.product')
+
+        website = website_obj.browse(
+            cursor, user, context['active_id'], context
+        )
+
+        record = self.browse(cursor, user, ids[0], context=context)
+
+        context.update({
+            'magento_website': website.id,
+            'magento_attribute_set': record.attribute_set,
+        })
+        for product in record.products:
+            product_obj.export_to_magento(
+                cursor, user, product, record.category, context=context
+            )
+
+        return self.open_products(
+            cursor, user, ids, map(int, record.products), context
+        )
+
+    def open_products(self, cursor, user, ids, product_ids, context):
+        """
+        Opens view for products exported to current website
+
+        :param cursor: Database cursor
+        :param user: ID of current user
+        :param ids: List of ids of records for this model
+        :param product_ids: List or product IDs
+        :param context: Application context
+        :return: View for products
+        """
+        ir_model_data = self.pool.get('ir.model.data')
+
+        model, tree_id = ir_model_data.get_object_reference(
+            cursor, user, 'product', 'product_product_tree_view'
+        )
+
+        return {
+            'name': _('Products exported to magento'),
+            'view_type': 'form',
+            'view_mode': 'form,tree',
+            'res_model': 'product.product',
+            'views': [(tree_id, 'tree')],
+            'context': context,
+            'type': 'ir.actions.act_window',
+            'domain': [('id', 'in', product_ids)]
+        }

--- a/wizard/export_catalog.xml
+++ b/wizard/export_catalog.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_magento_export_catalog" model="ir.ui.view">
+            <field name="name">magento.instance.website.export_catalog.form</field>
+            <field name="model">magento.instance.website.export_catalog</field>
+            <field name="arch" type="xml">
+                <form string="Export Catalog" version="7.0">
+                    <field name="id" invisible="1"/>
+                    <group>
+                        <h3 class="oe_grey">
+                            This wizard will export the products selected to the
+                            category selected to this current website.
+                        </h3>
+                    </group>
+                    <group>
+                        <label for="category"/>
+                        <h3><field name="category"/></h3>
+                        <label for="attribute_set"/>
+                        <h3><field name="attribute_set" context="{'active_id':active_id}"/></h3>
+                    </group>
+                    <group>
+                        <separator string="Select products to export"/>
+                        <field name="products" nolabel="1" colspan="4"/>
+                    </group>
+                    <footer>
+                        <button string="Continue" type="object"
+                            name="export_catalog" />
+                        or
+                        <button string="Close" special="cancel" class="oe_link"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <record id="action_magento_export_catalog" model="ir.actions.act_window">
+            <field name="name">Export Catalog</field>
+            <field name="res_model">magento.instance.website.export_catalog</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+           <field name="view_id" ref="view_magento_export_catalog"/>
+            <field name="context">{'active_id':active_id}</field>
+       </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
Export products from openerp to magento.

All the products selected for export will be exported to a category, attribute
set chosen by the user from a wizard. The exported products will always be
exported as simple products as other product types need attribute management
which better be left to magento. Other required details like weight, tax class
etc will be hardcoded to some default values which can later be configured on
magento itself.
