### PR TITLE
Import category tree based on ID specified on website #2096 fixes #89

### DIFF
--- a/magento.xml
+++ b/magento.xml
@@ -214,6 +214,7 @@
                                 <field name="instance"/>
                                 <field name="company"/>
                                 <field name="default_product_uom"/>
+                                <field name="magento_root_category_id"/>
                             </group>
                         </group>
                         <notebook>

--- a/magento_.py
+++ b/magento_.py
@@ -139,6 +139,13 @@ class InstanceWebsite(osv.Model):
             help="This is used to set UOM while creating products imported "
             "from magento",
         ),
+        magento_root_category_id=fields.integer(
+            'Magento Root Category ID', required=True,
+        )
+    )
+
+    _defaults = dict(
+        magento_root_category_id=lambda *a: 1,
     )
 
     _sql_constraints = [(

--- a/wizard/export_tier_prices.xml
+++ b/wizard/export_tier_prices.xml
@@ -23,7 +23,7 @@
         </record>
 
         <record id="action_magento_export_tier_prices" model="ir.actions.act_window">
-            <field name="name">Export Inventory</field>
+            <field name="name">Export Tier Prices</field>
             <field name="res_model">magento.store.export_tier_prices</field>
             <field name="view_type">form</field>
             <field name="view_mode">tree,form</field>

--- a/wizard/import_catalog.py
+++ b/wizard/import_catalog.py
@@ -31,26 +31,26 @@ class ImportCatalog(osv.TransientModel):
         website = website_obj.browse(
             cursor, user, context['active_id'], context
         )
-        instance = website.instance
 
-        self.import_category_tree(cursor, user, instance, context)
+        self.import_category_tree(cursor, user, website, context)
         product_ids = self.import_products(cursor, user, website, context)
 
         return self.open_products(
             cursor, user, ids, product_ids, context
         )
 
-    def import_category_tree(self, cursor, user, instance, context):
+    def import_category_tree(self, cursor, user, website, context):
         """
         Imports category tree
 
         :param cursor: Database cursor
         :param user: ID of current user
-        :param instance: Browse record of instance
+        :param website: Browse record of website
         :param context: Application context
         """
         category_obj = self.pool.get('product.category')
 
+        instance = website.instance
         context.update({
             'magento_instance': instance.id
         })
@@ -58,7 +58,7 @@ class ImportCatalog(osv.TransientModel):
         with Category(
             instance.url, instance.api_user, instance.api_key
         ) as category_api:
-            category_tree = category_api.tree()
+            category_tree = category_api.tree(website.magento_root_category_id)
 
             category_obj.create_tree_using_magento_data(
                 cursor, user, category_tree, context


### PR DESCRIPTION
The category tree import might fail sometimes if no ID is provided. Explicitly
allow the user to define the magento ID of a category on website and use it to
import category tree.
Also fix a wrong string for a button in XML.

Review: 303002
