### PR TITLE
Add instance to context for shipment status export #2126 fixes #97

### DIFF
--- a/magento_.py
+++ b/magento_.py
@@ -622,6 +622,9 @@ class WebsiteStoreView(osv.Model):
             ids = self.search(cursor, user, [], context)
 
         for store_view in self.browse(cursor, user, ids, context):
+            # Set the instance in context
+            context['magento_instance'] = store_view.instance.id
+
             self.export_shipment_status_to_magento(
                 cursor, user, store_view, context
             )


### PR DESCRIPTION
When export shipment status is called from cron it
does not have the magento instance set in context.
This patch sets the instance to context.

Review: 308002
