### PR TITLE
Handle context gracefully fixes #123

### DIFF
--- a/magento_.py
+++ b/magento_.py
@@ -623,7 +623,12 @@ class WebsiteStoreView(osv.Model):
 
         for store_view in self.browse(cursor, user, ids, context):
             # Set the instance in context
-            context['magento_instance'] = store_view.instance.id
+            if context:
+                context['magento_instance'] = store_view.instance.id
+            else:
+                context = {
+                    'magento_instance': store_view.instance.id
+                }
 
             self.export_shipment_status_to_magento(
                 cursor, user, store_view, context


### PR DESCRIPTION
Context is defined as None in method definition.
The cron call does not provide a context either.
Hence add a key to context only when its present else create new context
