### PR TITLE
Handle context copy gracefully

### DIFF
--- a/magento_.py
+++ b/magento_.py
@@ -518,7 +518,11 @@ class WebsiteStoreView(osv.Model):
         magento_state_obj = self.pool.get('magento.order_state')
 
         instance = store_view.instance
-        new_context = deepcopy(context)
+        if context:
+            new_context = deepcopy(context)
+        else:
+            new_context = {}
+
         new_context.update({
             'magento_instance': instance.id,
             'magento_website': store_view.website.id,


### PR DESCRIPTION
When import orders is called from cron, context comes in as None
We create a new context from original context which fails in this case
This patch handles this context gracefully and prevents cron from blowing
